### PR TITLE
add option to get way node refs in the geojson

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Converts OSM data into GeoJSON.
 * `data`: the OSM data. Either as a XML DOM or in [OSM JSON](http://overpass-api.de/output_formats.html#json).
 * `options`: optional. The following options can be used:
   * `flatProperties`: If true, the resulting GeoJSON feature's properties will be a simple key-value list instead of a structured json object (with separate tags and metadata). default: false
+  * `wayRefs`: If true, the GeoJSON will have a `ndrefs` property, which is an array of all the node members of the `way`. default: false
   * `uninterestingTags`: Either a [blacklist](https://github.com/tyrasd/osmtogeojson/blob/2.0.0/index.js#L14-L24) of tag keys or a callback function. Will be used to decide if a feature is *interesting* enough for its own GeoJSON feature.
   * `polygonFeatures`: Either a [json object](https://github.com/tyrasd/osmtogeojson/blob/2.0.0/polygon_features.json) or callback function that is used to determine if a closed way should be treated as a Polygon or LineString. [read more](https://wiki.openstreetmap.org/wiki/Overpass_turbo/Polygon_Features)
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ osmtogeojson = function( data, options, featureCallback ) {
     {
       verbose: false,
       flatProperties: true,
+      wayRefs: false,
       uninterestingTags: {
         "source": true,
         "source_ref": true,
@@ -455,7 +456,6 @@ osmtogeojson = function( data, options, featureCallback ) {
     return _convert2geoJSON(nodes,ways,rels);
   }
   function _convert2geoJSON(nodes,ways,rels) {
-
     // helper function that checks if there are any tags other than "created_by", "source", etc. or any tag provided in ignore_tags
     function has_interesting_tags(t, ignore_tags) {
       if (typeof ignore_tags !== "object")
@@ -510,12 +510,14 @@ osmtogeojson = function( data, options, featureCallback ) {
     var waynids = new Object();
     for (var i=0;i<ways.length;i++) {
       var way = ways[i];
+      way.ndrefs = [];
       if (wayids[way.id]) {
         // handle input data duplication
         way = options.deduplicator(way, wayids[way.id]);
       }
       wayids[way.id] = way;
       if (_.isArray(way.nodes)) {
+        way.ndrefs = Object.assign([], way.nodes)
         for (var j=0;j<way.nodes.length;j++) {
           if (typeof way.nodes[j] === "object") continue; // ignore already replaced way node objects
           waynids[way.nodes[j]] = true;
@@ -942,6 +944,11 @@ osmtogeojson = function( data, options, featureCallback ) {
           "coordinates" : coords,
         }
       }
+
+      if (options.wayRefs) {
+        feature.properties.ndrefs = ways[i].ndrefs
+      }
+
       if (ways[i].tainted) {
         if (options.verbose) console.warn('Way',ways[i].type+'/'+ways[i].id,'is tainted');
         feature.properties["tainted"] = true;

--- a/test/osm.test.js
+++ b/test/osm.test.js
@@ -2083,6 +2083,40 @@ describe("options", function () {
     result = osmtogeojson(json);
     expect(result.features[0].properties).to.eql(geojson_properties);
   });
+
+  it("add way node references", function () {
+    var xml, geojson;
+
+    xml = "<osm><way id='1'><nd ref='2' /><nd ref='3' /><nd ref='4' /></way><node id='2' lat='0.0' lon='1.0' /><node id='3' lat='0.0' lon='1.1' /><node id='4' lat='0.1' lon='1.2' /></osm>";
+    xml = (new DOMParser()).parseFromString(xml, 'text/xml');
+    geojson = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: "way/1",
+          properties: {
+            type: "way",
+            id: 1,
+            tags: {},
+            relations: [],
+            meta: {},
+            ndrefs: [2, 3, 4]
+          },
+          geometry: {
+            type: "LineString",
+            coordinates: [
+              [1.0,0.0],
+              [1.1,0.0],
+              [1.2,0.1],
+            ]
+          }
+        }
+      ]
+    };
+
+    expect(osmtogeojson(xml, {flatProperties: false, wayRefs: true})).to.eql(geojson);
+  })
   // interesting objects
   it("uninteresting tags", function () {
     var json;


### PR DESCRIPTION
This PR adds an option `wayRefs` to include all the node IDs that are part of the way in the properties of the geojson. 