### PR TITLE
[wip] All nodes option

### DIFF
--- a/index.js
+++ b/index.js
@@ -458,15 +458,16 @@ osmtogeojson = function( data, options, featureCallback ) {
   function _convert2geoJSON(nodes,ways,rels) {
     // helper function that checks if there are any tags other than "created_by", "source", etc. or any tag provided in ignore_tags
     function has_interesting_tags(t, ignore_tags) {
-      if (typeof ignore_tags !== "object")
-        ignore_tags={};
-      if (typeof options.uninterestingTags === "function")
-        return !options.uninterestingTags(t, ignore_tags);
-      for (var k in t)
-        if (!(options.uninterestingTags[k]===true) &&
-            !(ignore_tags[k]===true || ignore_tags[k]===t[k]))
-          return true;
-      return false;
+      return true;
+      // if (typeof ignore_tags !== "object")
+      //   ignore_tags={};
+      // if (typeof options.uninterestingTags === "function")
+      //   return !options.uninterestingTags(t, ignore_tags);
+      // for (var k in t)
+      //   if (!(options.uninterestingTags[k]===true) &&
+      //       !(ignore_tags[k]===true || ignore_tags[k]===t[k]))
+      //     return true;
+      // return false;
     };
     // helper function to extract meta information
     function build_meta_information(object) {

--- a/index.js
+++ b/index.js
@@ -373,8 +373,8 @@ osmtogeojson = function( data, options, featureCallback ) {
       copy_attribute( node, nodeObject, 'changeset' );
       copy_attribute( node, nodeObject, 'uid' );
       copy_attribute( node, nodeObject, 'user' );
-      if (!_.isEmpty(tags))
-        nodeObject.tags = tags;
+      // if (!_.isEmpty(tags))
+      nodeObject.tags = tags;
       nodes.push(nodeObject);
     });
     // ways

--- a/index.js
+++ b/index.js
@@ -374,7 +374,7 @@ osmtogeojson = function( data, options, featureCallback ) {
       copy_attribute( node, nodeObject, 'changeset' );
       copy_attribute( node, nodeObject, 'uid' );
       copy_attribute( node, nodeObject, 'user' );
-      // always set nodeObject.tags to tags, even if tags is and empty object.
+      // always set nodeObject.tags to tags, even if tags is an empty object.
       // this ensures we get valid properties when returning data for all nodes
       nodeObject.tags = tags;
       nodes.push(nodeObject);

--- a/index.js
+++ b/index.js
@@ -374,10 +374,9 @@ osmtogeojson = function( data, options, featureCallback ) {
       copy_attribute( node, nodeObject, 'changeset' );
       copy_attribute( node, nodeObject, 'uid' );
       copy_attribute( node, nodeObject, 'user' );
-      if (!_.isEmpty(tags))
       // always set nodeObject.tags to tags, even if tags is and empty object.
       // this ensures we get valid properties when returning data for all nodes
-        nodeObject.tags = tags;
+      nodeObject.tags = tags;
       nodes.push(nodeObject);
     });
     // ways

--- a/osmtogeojson
+++ b/osmtogeojson
@@ -8,6 +8,7 @@ var osmtogeojson = require('./'),
         .boolean('n').describe('n', 'numeric properties. if set, the resulting GeoJSON feature\'s properties will be numbers if possible')
         .boolean('v').describe('v', 'verbose mode. output diagnostic information during processing')
         .boolean('m').describe('m', 'minify output json (no identation and linebreaks)')
+        .boolean('a').describe('a', 'return all nodes. if set, the resulting GeoJSON will contain ALL nodes as separate features, even those that do not have tags (i.e. that are parts of ways)  ')
         .boolean('ndjson').describe('ndjson', 'output newline delimited geojson instead of a single featurecollection (implies -m enabled)')
         .boolean('version').describe('version','display software version')
         .boolean('help').describe('help','print this help message'),
@@ -139,6 +140,7 @@ function legacyParsers(data) {
 function convert(data) {
     var geojson = osmtogeojson(data, {
         flatProperties: !enhanced_geojson,
+        allNodes: argv.a,
         verbose: argv.v
     }, argv.ndjson ? outputNdgeojson : null);
     if (!argv.ndjson)

--- a/test/osm.test.js
+++ b/test/osm.test.js
@@ -125,6 +125,100 @@ describe("osm (xml)", function () {
     expect(osmtogeojson(xml, {flatProperties: false})).to.eql(geojson);
   });
 
+  it("allNodes true", function () {
+    var xml, geojson;
+
+    xml = "<osm><way id='1'><nd ref='2' /><nd ref='3' /><nd ref='4' /></way><node id='2' lat='0.0' lon='1.0' /><node id='3' lat='0.0' lon='1.1' /><node id='4' lat='0.1' lon='1.2' /></osm>";
+    xml = (new DOMParser()).parseFromString(xml, 'text/xml');
+    geojson = {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "id": "way/1",
+          "properties": {
+            "type": "way",
+            "id": 1,
+            "tags": {},
+            "relations": [],
+            "meta": {}
+          },
+          "geometry": {
+            "type": "LineString",
+            "coordinates": [
+              [
+                1,
+                0
+              ],
+              [
+                1.1,
+                0
+              ],
+              [
+                1.2,
+                0.1
+              ]
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "id": "node/2",
+          "properties": {
+            "type": "node",
+            "id": "2",
+            "tags": {},
+            "relations": [],
+            "meta": {}
+          },
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              1,
+              0
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "id": "node/3",
+          "properties": {
+            "type": "node",
+            "id": "3",
+            "tags": {},
+            "relations": [],
+            "meta": {}
+          },
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              1.1,
+              0
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "id": "node/4",
+          "properties": {
+            "type": "node",
+            "id": "4",
+            "tags": {},
+            "relations": [],
+            "meta": {}
+          },
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              1.2,
+              0.1
+            ]
+          }
+        }
+      ]
+    };
+    expect(osmtogeojson(xml, {flatProperties: false, allNodes: true})).to.eql(geojson);
+  });
 
 });
 


### PR DESCRIPTION
This adds an `allNodes` option where if set to `true`, it will return all nodes, including ones with no tags.

@geohacker let's not merge right away - if this approach looks okay, I can add some tests.