### PR TITLE
Node reverse lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,9 +399,9 @@ osmtogeojson = function( data, options, featureCallback ) {
           thisNode = _find(nodes, ['id', id])
           if (thisNode) {
             if (!thisNode.hasOwnProperty('ways')) {
-              thisNode.ways = []
+              thisNode.ways = {}
             }
-            thisNode.ways.push(wayId)
+            thisNode.ways[wayId] = i
           }
         if (!has_full_geometry && nd.getAttribute('lat'))
           has_full_geometry = true;

--- a/index.js
+++ b/index.js
@@ -1,16 +1,11 @@
 var _ = require("./lodash.custom.js");
 var _find = require("lodash.find")
 var _isEqual = require("lodash.isequal")
-var mbRewind = require("geojson-rewind");
+//var rewind = require("geojson-rewind");
 
+// for Observe, we don't want to rewind the features
 function rewind (feature) {
-  const rewoundFeature = mbRewind(feature)
-  if (!_isEqual(rewoundFeature, feature)) {
-    rewoundFeature.properties.isRewound = true
-  } else {
-    rewoundFeature.properties.isRewound = false
-  }
-  return rewoundFeature
+  return feature
 }
 
 // see https://wiki.openstreetmap.org/wiki/Overpass_turbo/Polygon_Features

--- a/index.js
+++ b/index.js
@@ -1,6 +1,17 @@
 var _ = require("./lodash.custom.js");
 var _find = require("lodash.find")
-var rewind = require("geojson-rewind");
+var _isEqual = require("lodash.isequal")
+var mbRewind = require("geojson-rewind");
+
+function rewind (feature) {
+  const rewoundFeature = mbRewind(feature)
+  if (!_isEqual(rewoundFeature, feature)) {
+    rewoundFeature.properties.isRewound = true
+  } else {
+    rewoundFeature.properties.isRewound = false
+  }
+  return rewoundFeature
+}
 
 // see https://wiki.openstreetmap.org/wiki/Overpass_turbo/Polygon_Features
 var polygonFeatures = {};

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var _ = require("./lodash.custom.js");
+var _find = require("lodash.find")
 var rewind = require("geojson-rewind");
 
 // see https://wiki.openstreetmap.org/wiki/Overpass_turbo/Polygon_Features
@@ -392,8 +393,16 @@ osmtogeojson = function( data, options, featureCallback ) {
       var has_full_geometry = false;
       _.each( way.getElementsByTagName('nd'), function( nd, i ) {
         var id;
+        var wayId = way.getAttribute('id')
         if (id = nd.getAttribute('ref'))
           wnodes[i] = id;
+          thisNode = _find(nodes, ['id', id])
+          if (thisNode) {
+            if (!thisNode.hasOwnProperty('ways')) {
+              thisNode.ways = []
+            }
+            thisNode.ways.push(wayId)
+          }
         if (!has_full_geometry && nd.getAttribute('lat'))
           has_full_geometry = true;
       });

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "geojson-rewind": "0.3.0",
     "htmlparser2": "3.5.1",
     "lodash.find": "^4.6.0",
+    "lodash.isequal": "^4.5.0",
     "optimist": "~0.3.5",
     "osm-polygon-features": "^0.9.1",
     "tiny-osmpbf": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "geojson-numeric": "0.2.0",
     "geojson-rewind": "0.3.0",
     "htmlparser2": "3.5.1",
+    "lodash.find": "^4.6.0",
     "optimist": "~0.3.5",
     "osm-polygon-features": "^0.9.1",
     "tiny-osmpbf": "^0.1.0",

--- a/test/osm.test.js
+++ b/test/osm.test.js
@@ -133,7 +133,7 @@ describe("osm (xml)", function () {
 
     expectedResult = {
       "geojson": {
-        "type": "FeatureCollection",
+          "type": "FeatureCollection",
           "features": [
               {
                   "type": "Feature",
@@ -220,10 +220,9 @@ describe("osm (xml)", function () {
               "lat": "-1.0",
               "lon": "-1.0",
               "tags": {},
-              "ways": [
-                  "2",
-                  "2"
-              ]
+              "ways": {
+                  "2": 4
+              }
           },
           {
               "type": "node",
@@ -231,9 +230,9 @@ describe("osm (xml)", function () {
               "lat": "-1.0",
               "lon": "1.0",
               "tags": {},
-              "ways": [
-                  "2"
-              ]
+              "ways": {
+                  "2": 1
+              }
           },
           {
               "type": "node",
@@ -241,9 +240,9 @@ describe("osm (xml)", function () {
               "lat": "1.0",
               "lon": "1.0",
               "tags": {},
-              "ways": [
-                  "2"
-              ]
+              "ways": {
+                  "2": 2
+              }
           },
           {
               "type": "node",
@@ -251,9 +250,9 @@ describe("osm (xml)", function () {
               "lat": "1.0",
               "lon": "-1.0",
               "tags": {},
-              "ways": [
-                  "2"
-              ]
+              "ways": {
+                  "2": 3
+              }
           },
           {
               "type": "node",
@@ -261,10 +260,9 @@ describe("osm (xml)", function () {
               "lat": "-0.5",
               "lon": "0.0",
               "tags": {},
-              "ways": [
-                  "3",
-                  "3"
-              ]
+              "ways": {
+                  "3": 3
+              }
           },
           {
               "type": "node",
@@ -272,9 +270,9 @@ describe("osm (xml)", function () {
               "lat": "0.5",
               "lon": "0.0",
               "tags": {},
-              "ways": [
-                  "3"
-              ]
+              "ways": {
+                  "3": 1
+              }
           },
           {
               "type": "node",
@@ -282,12 +280,12 @@ describe("osm (xml)", function () {
               "lat": "0.0",
               "lon": "0.5",
               "tags": {},
-              "ways": [
-                  "3"
-              ]
+              "ways": {
+                  "3": 2
+              }
           }
       ]
-    };
+  };
     expect(osmtogeojson(xml, {flatProperties: false, mapRelations: true})).to.eql(expectedResult);
   });
 });

--- a/test/osm.test.js
+++ b/test/osm.test.js
@@ -134,135 +134,158 @@ describe("osm (xml)", function () {
     expectedResult = {
       "geojson": {
         "type": "FeatureCollection",
-        "features": [
-          {
-            "type": "Feature",
-            "id": "way/2",
-            "properties": {
-              "type": "way",
-              "id": 2,
-              "tags": {
-                "area": "yes"
+          "features": [
+              {
+                  "type": "Feature",
+                  "id": "way/2",
+                  "properties": {
+                      "type": "way",
+                      "id": 2,
+                      "tags": {
+                          "area": "yes"
+                      },
+                      "relations": [],
+                      "meta": {}
+                  },
+                  "geometry": {
+                      "type": "Polygon",
+                      "coordinates": [
+                          [
+                              [
+                                  -1,
+                                  -1
+                              ],
+                              [
+                                  1,
+                                  -1
+                              ],
+                              [
+                                  1,
+                                  1
+                              ],
+                              [
+                                  -1,
+                                  1
+                              ],
+                              [
+                                  -1,
+                                  -1
+                              ]
+                          ]
+                      ]
+                  }
               },
-              "relations": [],
-              "meta": {}
-            },
-            "geometry": {
-              "type": "Polygon",
-              "coordinates": [
-                [
-                  [
-                    -1,
-                    -1
-                  ],
-                  [
-                    1,
-                    -1
-                  ],
-                  [
-                    1,
-                    1
-                  ],
-                  [
-                    -1,
-                    1
-                  ],
-                  [
-                    -1,
-                    -1
-                  ]
-                ]
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "id": "way/3",
-            "properties": {
-              "type": "way",
-              "id": 3,
-              "tags": {},
-              "relations": [],
-              "meta": {}
-            },
-            "geometry": {
-              "type": "LineString",
-              "coordinates": [
-                [
-                  0,
-                  -0.5
-                ],
-                [
-                  0,
-                  0.5
-                ],
-                [
-                  0.5,
-                  0
-                ],
-                [
-                  0,
-                  -0.5
-                ]
-              ]
-            }
-          }
-        ]
+              {
+                  "type": "Feature",
+                  "id": "way/3",
+                  "properties": {
+                      "type": "way",
+                      "id": 3,
+                      "tags": {},
+                      "relations": [],
+                      "meta": {}
+                  },
+                  "geometry": {
+                      "type": "LineString",
+                      "coordinates": [
+                          [
+                              0,
+                              -0.5
+                          ],
+                          [
+                              0,
+                              0.5
+                          ],
+                          [
+                              0.5,
+                              0
+                          ],
+                          [
+                              0,
+                              -0.5
+                          ]
+                      ]
+                  }
+              }
+          ]
       },
       "featuresInRelation": [
-        "way/2",
-        "way/3"
+          "way/2",
+          "way/3"
       ],
       "nodes": [
-        {
-          "type": "node",
-          "id": "4",
-          "lat": "-1.0",
-          "lon": "-1.0",
-          "tags": {}
-        },
-        {
-          "type": "node",
-          "id": "5",
-          "lat": "-1.0",
-          "lon": "1.0",
-          "tags": {}
-        },
-        {
-          "type": "node",
-          "id": "6",
-          "lat": "1.0",
-          "lon": "1.0",
-          "tags": {}
-        },
-        {
-          "type": "node",
-          "id": "7",
-          "lat": "1.0",
-          "lon": "-1.0",
-          "tags": {}
-        },
-        {
-          "type": "node",
-          "id": "8",
-          "lat": "-0.5",
-          "lon": "0.0",
-          "tags": {}
-        },
-        {
-          "type": "node",
-          "id": "9",
-          "lat": "0.5",
-          "lon": "0.0",
-          "tags": {}
-        },
-        {
-          "type": "node",
-          "id": "10",
-          "lat": "0.0",
-          "lon": "0.5",
-          "tags": {}
-        }
+          {
+              "type": "node",
+              "id": "4",
+              "lat": "-1.0",
+              "lon": "-1.0",
+              "tags": {},
+              "ways": [
+                  "2",
+                  "2"
+              ]
+          },
+          {
+              "type": "node",
+              "id": "5",
+              "lat": "-1.0",
+              "lon": "1.0",
+              "tags": {},
+              "ways": [
+                  "2"
+              ]
+          },
+          {
+              "type": "node",
+              "id": "6",
+              "lat": "1.0",
+              "lon": "1.0",
+              "tags": {},
+              "ways": [
+                  "2"
+              ]
+          },
+          {
+              "type": "node",
+              "id": "7",
+              "lat": "1.0",
+              "lon": "-1.0",
+              "tags": {},
+              "ways": [
+                  "2"
+              ]
+          },
+          {
+              "type": "node",
+              "id": "8",
+              "lat": "-0.5",
+              "lon": "0.0",
+              "tags": {},
+              "ways": [
+                  "3",
+                  "3"
+              ]
+          },
+          {
+              "type": "node",
+              "id": "9",
+              "lat": "0.5",
+              "lon": "0.0",
+              "tags": {},
+              "ways": [
+                  "3"
+              ]
+          },
+          {
+              "type": "node",
+              "id": "10",
+              "lat": "0.0",
+              "lon": "0.5",
+              "tags": {},
+              "ways": [
+                  "3"
+              ]
+          }
       ]
     };
     expect(osmtogeojson(xml, {flatProperties: false, mapRelations: true})).to.eql(expectedResult);


### PR DESCRIPTION
This PR naively adds a `ways` props to nodes in the JSON response that has the way id and the position of the node in the way.